### PR TITLE
Update tests pipeline to php 8.1 and php 8.2

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -21,7 +21,7 @@ jobs:
 
     strategy:
       matrix:
-        php: [8.0]
+        php: [8.1, 8.2]
         dependencies: [locked]
 
     steps:


### PR DESCRIPTION
Update tests pipeline to run the pipelines with correct php so composer does not break.