### PR TITLE
DX: Add composer keywords

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -2,6 +2,7 @@
     "name": "tomasvotruba/bladestan",
     "description": "PHPStan rule for static analysis of Blade templates",
     "license": "MIT",
+    "type": "phpstan-extension",
     "keywords": ["static analysis", "phpstan-extension"],
     "require": {
         "php": "^8.1",

--- a/composer.json
+++ b/composer.json
@@ -3,7 +3,6 @@
     "description": "PHPStan rule for static analysis of Blade templates",
     "license": "MIT",
     "keywords": ["static analysis", "phpstan-extension"],
-DX: Add composer keywords    "type": "phpstan-extension",
     "require": {
         "php": "^8.1",
         "illuminate/contracts": "^8.8 || ^9.0 || ^10.0",

--- a/composer.json
+++ b/composer.json
@@ -2,7 +2,8 @@
     "name": "tomasvotruba/bladestan",
     "description": "PHPStan rule for static analysis of Blade templates",
     "license": "MIT",
-    "type": "phpstan-extension",
+    "keywords": ["static analysis", "phpstan-extension"],
+DX: Add composer keywords    "type": "phpstan-extension",
     "require": {
         "php": "^8.1",
         "illuminate/contracts": "^8.8 || ^9.0 || ^10.0",


### PR DESCRIPTION
as per https://github.com/composer/composer/pull/10960 this allows composer to warn the user, when installing the tool as a project dependency instead of a dev-dependency