### PR TITLE
Fix processing @include with data given in a variable

### DIFF
--- a/src/Compiler/BladeToPHPCompiler.php
+++ b/src/Compiler/BladeToPHPCompiler.php
@@ -33,16 +33,16 @@ use Webmozart\Assert\Assert;
 final class BladeToPHPCompiler
 {
     /**
-     * @see https://regex101.com/r/BGw7Lf/1
+     * @see https://regex101.com/r/8wK28k/1
      * @var string
      */
-    private const VIEW_INCLUDE_REGEX = '#\$__env->make\(\'(.*?)\',( \[(.*?)?],)? \\\Illuminate\\\Support\\\Arr::except\(get_defined_vars\(\), \[\'__data\', \'__path\']\)\)->render\(\)#s';
+    private const VIEW_INCLUDE_REGEX = '/\$__env->make\(\'(.*?)\',( \[(.*?)?\],| \$[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*?,)? \\\\Illuminate\\\\Support\\\\Arr::except\(get_defined_vars\(\), \[\'__data\', \'__path\']\)\)->render\(\)/s';
 
     /**
-     * @see https://regex101.com/r/BGw7Lf/1
+     * @see https://regex101.com/r/8wK28k/1
      * @var string
      */
-    private const VIEW_INCLUDE_REPLACE_REGEX = '#echo \$__env->make\(\'%s\',( \[(.*?)?],)? \\\Illuminate\\\Support\\\Arr::except\(get_defined_vars\(\), \[\'__data\', \'__path\']\)\)->render\(\);#s';
+    private const VIEW_INCLUDE_REPLACE_REGEX = '/echo \$__env->make\(\'%s\',( \[(.*?)?\],| \$[a-zA-Z_\x7f-\xff][a-zA-Z0-9_\x7f-\xff]*?,)? \\\\Illuminate\\\\Support\\\\Arr::except\(get_defined_vars\(\), \[\'__data\', \'__path\']\)\)->render\(\);/s';
 
     /**
      * @var string

--- a/tests/Rules/BladeRuleTest.php
+++ b/tests/Rules/BladeRuleTest.php
@@ -62,6 +62,9 @@ final class BladeRuleTest extends RuleTestCase
                 ['Undefined variable: $bar', 28],
                 ['Binary operation "+" between string and 10 results in an error.', 33],
                 ['Variable $bar might not be defined.', 33],
+                ['Binary operation "+" between string and \'bar\' results in an error.', 35],
+                ['If condition is always true.', 35],
+                ['Binary operation "+" between string and \'bar\' results in an error.', 35],
             ],
         ];
 

--- a/tests/Rules/Fixture/laravel-view-function.php
+++ b/tests/Rules/Fixture/laravel-view-function.php
@@ -31,3 +31,7 @@ view('file_with_recursive_include', [
 
 $foo = 'foo';
 view('simple_variable', compact('foo'));
+
+view('include_with_parameters', [
+    'includeData' => [],
+]);

--- a/tests/Rules/templates/include_with_parameters.blade.php
+++ b/tests/Rules/templates/include_with_parameters.blade.php
@@ -1,0 +1,4 @@
+@include('bar', $includeData)
+@if(true)
+	@include('bar')
+@endif


### PR DESCRIPTION
Fixes #26

The regex was not taking including data as a variable in to account, and there where also some minor errors in how the string was escaped.

The block for matching variable names was taken from here:
https://www.php.net/language.variables.basics

Proper escaping was done by using regex101's generate code function, this is also why `#` was swapped for `/` so the code can be copied directly in the future with out having to manually modify it.

Technically `@include` accepts arbitrary PHP, but this will at least give everyone a way to adjust things to something that works.

Example:
```php
@include('template', ['foo' => 'bar', ...$extra] + more())
```

Can now be written as:
```php
@php
$data = ['foo' => 'bar', ...$extra] + more();
@endphp
@include('template', $data)
```