### PR TITLE
Import mapped variables into scope

### DIFF
--- a/tests/Compiler/BladeToPHPCompiler/Fixture/basic_include.blade.php
+++ b/tests/Compiler/BladeToPHPCompiler/Fixture/basic_include.blade.php
@@ -3,6 +3,6 @@
 <?php
 
 /** file: foo.blade.php, line: 1 */
-function () {
+function () use($data) {
     $data = $data;
 };

--- a/tests/Rules/BladeRuleTest.php
+++ b/tests/Rules/BladeRuleTest.php
@@ -76,6 +76,11 @@ final class BladeRuleTest extends RuleTestCase
             ['Binary operation "+" between string and 10 results in an error.', 9],
             ['Binary operation "+" between string and \'bar\' results in an error.', 9],
         ]];
+
+        yield [
+            __DIR__ . '/Fixture/laravel-view-include.php',
+            [['Binary operation "+" between string and \'bar\' results in an error.', 9]],
+        ];
     }
 
     /**

--- a/tests/Rules/Fixture/laravel-view-include.php
+++ b/tests/Rules/Fixture/laravel-view-include.php
@@ -1,0 +1,11 @@
+<?php
+
+declare(strict_types=1);
+
+namespace LaravelViewFunction;
+
+use function view;
+
+view('foreach-include', [
+    'foos' => ['foobar'],
+]);

--- a/tests/Rules/templates/foreach-include.blade.php
+++ b/tests/Rules/templates/foreach-include.blade.php
@@ -1,0 +1,3 @@
+@foreach($foos as $value)
+	@include('bar', ['foo' => $value])
+@endforeach


### PR DESCRIPTION
Fixes #31

This fixes the issue where variables created by `@foreach()` are not imported in to the scope of the `Closure`.

Specifically this is done by explicitly include the variables used in the alias expression of the `@include` directive.

That way things like `['amphibians' => $frogs + $toads, 'msg' => 'Welcome ' . $name]` are correctly handled as well.

This also means that errors where an undefined variable is used will cause a single error at the place of `@include` rather then for ever usage in the included template.