### PR TITLE
Fix whitespace error

### DIFF
--- a/src/Compiler/PhpContentExtractor.php
+++ b/src/Compiler/PhpContentExtractor.php
@@ -41,7 +41,7 @@ final class PhpContentExtractor
 
         $phpContents = array_map(static fn ($a, $b): string => $a . rtrim((string) $b), $matches[1], $matches[2]);
 
-        if ($phpContents !== [] && $addPHPOpeningTag) {
+        if ($addPHPOpeningTag) {
             array_unshift($phpContents, '<?php');
         }
 

--- a/tests/Rules/Fixture/laravel-view-function.php
+++ b/tests/Rules/Fixture/laravel-view-function.php
@@ -35,3 +35,5 @@ view('simple_variable', compact('foo'));
 view('include_with_parameters', [
     'includeData' => [],
 ]);
+
+view('static_content');

--- a/tests/Rules/templates/static_content.blade.php
+++ b/tests/Rules/templates/static_content.blade.php
@@ -1,0 +1,1 @@
+A plane file


### PR DESCRIPTION
Fixes #42

The issue here was that the if no PHP was gathered from the template then it would not add a php opening tag but still join a line break which looks improper to PHPStan. So now we simply always add the opening tag, not adding it was probably an unnecessary optimization anyway.

With this the project I work on is now able to parse with out any errors on level 0 :tada:

```
Language                     files          blank        comment           code
-------------------------------------------------------------------------------
Blade                          552           4243           1837          63784
```