### PR TITLE
Create new $loop rather then replacing it with a docblock

### DIFF
--- a/src/PhpParser/NodeVisitor/AddLoopVarTypeToForeachNodeVisitor.php
+++ b/src/PhpParser/NodeVisitor/AddLoopVarTypeToForeachNodeVisitor.php
@@ -39,7 +39,7 @@ final class AddLoopVarTypeToForeachNodeVisitor extends NodeVisitorAbstract
         }
 
         $docNop = new Nop();
-        $docNop->setDocComment(new Doc(sprintf('/** @var %s $%s */', '\\' . Loop::class, 'loop')));
+        $docNop->setDocComment(new Doc('$loop = new \\' . Loop::class . '();'));
 
         // Add `$loop` var doc type as the first statement
         array_unshift($node->stmts, $docNop);

--- a/tests/Compiler/BladeToPHPCompiler/Fixture/nested_if_and_foreach.blade.php
+++ b/tests/Compiler/BladeToPHPCompiler/Fixture/nested_if_and_foreach.blade.php
@@ -19,7 +19,7 @@ if (isset($errors)) {
         /** file: foo.blade.php, line: 5 */
         $__currentLoopData = $errors->all();
         foreach ($__currentLoopData as $error) {
-            /** @var \TomasVotruba\Bladestan\ValueObject\Loop $loop */
+            $loop = new \TomasVotruba\Bladestan\ValueObject\Loop();
             /** file: foo.blade.php, line: 6 */
             echo $error;
             unset($loop);


### PR DESCRIPTION
In some cases the previous implementation would generate the following code:
```cpp
    foreach ($__currentLoopData as $productGroup) {
        /** @var \TomasVotruba\Bladestan\ValueObject\Loop $loop */
            if ($loop->first) {
                ?> class="active" <?php 
            }
        unset($loop);
    }
```
The new solution instead does the following:
In some cases the previous implementation would generate the following code:
```cpp
    foreach ($__currentLoopData as $productGroup) {
        $loop = \TomasVotruba\Bladestan\ValueObject\Loop();
            if ($loop->first) {
                ?> class="active" <?php 
            }
        unset($loop);
    }
```
This looks to probably have been related to some bad assumptions about the actual code structure.