### PR TITLE
Fix $loop in nested @foreach

### DIFF
--- a/src/PhpParser/NodeVisitor/AddLoopVarTypeToForeachNodeVisitor.php
+++ b/src/PhpParser/NodeVisitor/AddLoopVarTypeToForeachNodeVisitor.php
@@ -19,11 +19,30 @@ use TomasVotruba\Bladestan\ValueObject\Loop;
 final class AddLoopVarTypeToForeachNodeVisitor extends NodeVisitorAbstract
 {
     /**
+     * @var array<bool>
+     */
+    private array $loopStack = [];
+
+    public function enterNode(Node $node): ?Node
+    {
+        if ($node instanceof Foreach_) {
+            array_push($this->loopStack, true);
+        }
+
+        return $node;
+    }
+
+    /**
      * @return Node[]|null
      */
     public function leaveNode(Node $node): ?array
     {
         if (! $node instanceof Foreach_) {
+            return null;
+        }
+
+        array_pop($this->loopStack);
+        if (count($this->loopStack) !== 0) {
             return null;
         }
 

--- a/src/PhpParser/NodeVisitor/AddLoopVarTypeToForeachNodeVisitor.php
+++ b/src/PhpParser/NodeVisitor/AddLoopVarTypeToForeachNodeVisitor.php
@@ -6,9 +6,12 @@ namespace TomasVotruba\Bladestan\PhpParser\NodeVisitor;
 
 use PhpParser\Comment\Doc;
 use PhpParser\Node;
+use PhpParser\Node\Expr\Assign;
+use PhpParser\Node\Expr\New_;
 use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Name\FullyQualified;
+use PhpParser\Node\Stmt\Expression;
 use PhpParser\Node\Stmt\Foreach_;
-use PhpParser\Node\Stmt\Nop;
 use PhpParser\Node\Stmt\Unset_;
 use PhpParser\NodeVisitorAbstract;
 use TomasVotruba\Bladestan\ValueObject\Loop;
@@ -38,11 +41,10 @@ final class AddLoopVarTypeToForeachNodeVisitor extends NodeVisitorAbstract
             return null;
         }
 
-        $docNop = new Nop();
-        $docNop->setDocComment(new Doc('$loop = new \\' . Loop::class . '();'));
+        $assing = new Expression(new Assign(new Variable('loop'), new New_(new FullyQualified(Loop::class))));
 
-        // Add `$loop` var doc type as the first statement
-        array_unshift($node->stmts, $docNop);
+        // Add `$loop` var as the first statement
+        array_unshift($node->stmts, $assing);
 
         // `endforeach` also has a doc comment. Remove that before adding our unset.
         array_pop($node->stmts);

--- a/tests/Rules/BladeRuleTest.php
+++ b/tests/Rules/BladeRuleTest.php
@@ -65,6 +65,7 @@ final class BladeRuleTest extends RuleTestCase
                 ['Binary operation "+" between string and \'bar\' results in an error.', 35],
                 ['If condition is always true.', 35],
                 ['Binary operation "+" between string and \'bar\' results in an error.', 35],
+                ['Variable $foos might not be defined.', 41],
             ],
         ];
 

--- a/tests/Rules/Fixture/laravel-view-function.php
+++ b/tests/Rules/Fixture/laravel-view-function.php
@@ -37,3 +37,5 @@ view('include_with_parameters', [
 ]);
 
 view('static_content');
+
+view('nested-foreach');

--- a/tests/Rules/templates/nested-foreach.blade.php
+++ b/tests/Rules/templates/nested-foreach.blade.php
@@ -1,0 +1,8 @@
+@foreach($foos as $values)
+    @foreach($values as $value)
+        {{ $value }}
+    @endforeach
+    @if($loop->first)
+        What a short list!
+    @endif
+@endforeach


### PR DESCRIPTION
Previously the code would generate an `unset()` for `$loop` each time a loop ended. This however means that $loop was not available after a nested loop, which is not how Blade works.

```php
foreach ($items as $item) {
    $loop = new Loop();
    foreach ($item->names as $name) {
        $loop = new Loop();
        echo $name;
        unset($loop); // <-- outloop nolonger has a context
    }
    echo $loop->odd ? 'odd-button.png' : 'even-button.png';
    unset($loop);
}
```

PR:
```php
foreach ($items as $item) {
    $loop = new Loop();
    foreach ($item->names as $name) {
        echo $name;
    }
    echo $loop->odd ? 'odd-button.png' : 'even-button.png';
    unset($loop);
}
```

Additionally I replaced the hack I did for creating the loop (using a comment) with the proper way of doing so now that I know how PhpParser works.

This indeed did solve the last of the errors I was getting for the two projects I work on for a living.