### PR TITLE
Resolve Larastan conflict BladeToPHPCompiler

### DIFF
--- a/src/Compiler/BladeToPHPCompiler.php
+++ b/src/Compiler/BladeToPHPCompiler.php
@@ -235,12 +235,7 @@ STRING;
             return;
         }
 
-        // Hack to make the compiler work
-        $application = new Application($currentWorkingDirectory);
-        $application->bind(
-            \Illuminate\Contracts\Foundation\Application::class,
-            static fn (): Application => $application
-        );
+        $application = Application::getInstance();
         $application->bind(
             Factory::class,
             fn (): \Illuminate\View\Factory => new \Illuminate\View\Factory(


### PR DESCRIPTION
I'm unsure why this hack was ever needed but it's the cause of https://github.com/TomasVotruba/bladestan/issues/75 and https://github.com/TomasVotruba/bladestan/issues/30

It also breaks analyzing `resolve()` and `app()`.

I tested on the projects I worked on both with and without Larastan enabled after making this change to the code and both appeared to work correctly so this looks to only fix issues and not break anything (tests are also working).