### PR TITLE
refactor: decouple internals

### DIFF
--- a/src/Rules/BladeRule.php
+++ b/src/Rules/BladeRule.php
@@ -35,7 +35,7 @@ final class BladeRule implements Rule
 
     public function getNodeType(): string
     {
-        return Node::class;
+        return Node\Expr\CallLike::class;
     }
 
     public function processNode(Node $node, Scope $scope): array

--- a/src/Rules/BladeRule.php
+++ b/src/Rules/BladeRule.php
@@ -35,7 +35,7 @@ final class BladeRule implements Rule
 
     public function getNodeType(): string
     {
-        return Node\Expr\CallLike::class;
+        return Node::class;
     }
 
     public function processNode(Node $node, Scope $scope): array

--- a/src/ValueObject/CompiledTemplate.php
+++ b/src/ValueObject/CompiledTemplate.php
@@ -1,0 +1,23 @@
+<?php
+
+declare(strict_types=1);
+
+namespace TomasVotruba\Bladestan\ValueObject;
+
+final class CompiledTemplate {
+    public function __construct(
+        private readonly string $filePath,
+        private readonly PhpFileContentsWithLineMap $lineMap
+    ) {}
+
+    public function getFilePath(): string
+    {
+        return $this->filePath;
+    }
+
+    public function getLineMap(): PhpFileContentsWithLineMap
+    {
+        return $this->lineMap;
+    }
+
+}

--- a/src/ValueObject/CompiledTemplate.php
+++ b/src/ValueObject/CompiledTemplate.php
@@ -4,11 +4,13 @@ declare(strict_types=1);
 
 namespace TomasVotruba\Bladestan\ValueObject;
 
-final class CompiledTemplate {
+final class CompiledTemplate
+{
     public function __construct(
         private readonly string $filePath,
         private readonly PhpFileContentsWithLineMap $lineMap
-    ) {}
+    ) {
+    }
 
     public function getFilePath(): string
     {
@@ -19,5 +21,4 @@ final class CompiledTemplate {
     {
         return $this->lineMap;
     }
-
 }

--- a/src/ValueObject/CompiledTemplate.php
+++ b/src/ValueObject/CompiledTemplate.php
@@ -7,18 +7,30 @@ namespace TomasVotruba\Bladestan\ValueObject;
 final class CompiledTemplate
 {
     public function __construct(
-        private readonly string $filePath,
-        private readonly PhpFileContentsWithLineMap $lineMap
+        private readonly string $bladeFilePath,
+        private readonly string $phpFilePath,
+        private readonly PhpFileContentsWithLineMap $lineMap,
+        private readonly int $phpLine,
     ) {
     }
 
-    public function getFilePath(): string
+    public function getBladeFilePath(): string
     {
-        return $this->filePath;
+        return $this->bladeFilePath;
+    }
+
+    public function getPhpFilePath(): string
+    {
+        return $this->phpFilePath;
     }
 
     public function getLineMap(): PhpFileContentsWithLineMap
     {
         return $this->lineMap;
+    }
+
+    public function getPhpLine(): int
+    {
+        return $this->phpLine;
     }
 }

--- a/src/ViewRuleHelper.php
+++ b/src/ViewRuleHelper.php
@@ -76,8 +76,8 @@ final class ViewRuleHelper
      */
     private function processTemplateFilePath(
         CompiledTemplate $compiledTemplate,
-        string $filePath,
-        int $phpLine
+        string           $bladeFilePath,
+        int              $phpLine
     ): array {
 
         $fileAnalyser = $this->fileAnalyserProvider->provide();
@@ -100,7 +100,7 @@ final class ViewRuleHelper
         return $this->templateErrorsFactory->createErrors(
             $usefulRuleErrors,
             $phpLine,
-            $filePath,
+            $bladeFilePath,
             $compiledTemplate->getLineMap(),
         );
     }

--- a/src/ViewRuleHelper.php
+++ b/src/ViewRuleHelper.php
@@ -51,7 +51,7 @@ final class ViewRuleHelper
             $currentRuleErrors = $this->processTemplateFilePath(
                 $renderTemplateWithParameter->getTemplateFilePath(),
                 $variablesAndTypes,
-                $scope,
+                $scope->getFile(),
                 $call->getLine()
             );
 
@@ -69,7 +69,7 @@ final class ViewRuleHelper
     private function processTemplateFilePath(
         string $templateFilePath,
         array $variablesAndTypes,
-        Scope $scope,
+        string $filePath,
         int $phpLine
     ): array {
         $fileContents = file_get_contents($templateFilePath);
@@ -85,7 +85,7 @@ final class ViewRuleHelper
 
         $phpFileContents = $phpFileContentsWithLineMap->getPhpFileContents();
 
-        $tmpFilePath = sys_get_temp_dir() . '/' . md5($scope->getFile()) . '-blade-compiled.php';
+        $tmpFilePath = sys_get_temp_dir() . '/' . md5($filePath) . '-blade-compiled.php';
         file_put_contents($tmpFilePath, $phpFileContents);
 
         $fileAnalyser = $this->fileAnalyserProvider->provide();
@@ -108,7 +108,7 @@ final class ViewRuleHelper
         return $this->templateErrorsFactory->createErrors(
             $usefulRuleErrors,
             $phpLine,
-            $scope->getFile(),
+            $filePath,
             $phpFileContentsWithLineMap,
         );
     }

--- a/src/ViewRuleHelper.php
+++ b/src/ViewRuleHelper.php
@@ -79,7 +79,6 @@ final class ViewRuleHelper
         string           $bladeFilePath,
         int              $phpLine
     ): array {
-
         $fileAnalyser = $this->fileAnalyserProvider->provide();
 
         $collectorsRegistry = new \PHPStan\Collectors\Registry([]);

--- a/src/ViewRuleHelper.php
+++ b/src/ViewRuleHelper.php
@@ -60,9 +60,7 @@ final class ViewRuleHelper
                 continue;
             }
 
-            $currentRuleErrors = $this->processTemplateFilePath(
-                $compiledTemplate,
-            );
+            $currentRuleErrors = $this->processTemplateFilePath($compiledTemplate);
 
             $ruleErrors = array_merge($ruleErrors, $currentRuleErrors);
         }
@@ -73,9 +71,8 @@ final class ViewRuleHelper
     /**
      * @return RuleError[]
      */
-    private function processTemplateFilePath(
-        CompiledTemplate $compiledTemplate
-    ): array {
+    private function processTemplateFilePath(CompiledTemplate $compiledTemplate): array
+    {
         $fileAnalyser = $this->fileAnalyserProvider->provide();
 
         $collectorsRegistry = new \PHPStan\Collectors\Registry([]);


### PR DESCRIPTION
just refactoring, no logic changes.

idea is to separate the blade-compile from the analysis step.

this should make it possible to e.g. move blade template determination into a PHPStan-Collector and run the analysis on the compiled templates in a single PHPStan analysis call (maybe even in parallel) - or similar.