### PR TITLE
Fix $this type (#90)

### DIFF
--- a/src/TemplateCompiler/ValueObject/VariableAndType.php
+++ b/src/TemplateCompiler/ValueObject/VariableAndType.php
@@ -4,6 +4,7 @@ declare(strict_types=1);
 
 namespace TomasVotruba\Bladestan\TemplateCompiler\ValueObject;
 
+use PHPStan\Type\ThisType;
 use PHPStan\Type\Type;
 use PHPStan\Type\VerbosityLevel;
 
@@ -26,7 +27,10 @@ final class VariableAndType
     }
 
     public function getTypeAsString(): string
-    {
+    { 
+        if ($this->type instanceof ThisType) {
+            return $this->type->getStaticObjectType()->describe(VerbosityLevel::typeOnly());
+        }
         return $this->type->describe(VerbosityLevel::typeOnly());
     }
 }


### PR DESCRIPTION
Phpstan has a special formatter for $this which it can't actually parse itself if used in an @var block. 
This replaces it with the underlying type of $this.